### PR TITLE
Fix menu document

### DIFF
--- a/example/src/pages/menu/code.md
+++ b/example/src/pages/menu/code.md
@@ -3,7 +3,7 @@
 	<div slot="activator">
 		<Button color="primary" outlined ripple={false} style="padding-right: 4px;">
 			<span>Menu</span>
-			<Icon content={arrowDropDown} />
+			<Icon path={arrowDropDown} />
 		</Button>
 	</div>
 


### PR DESCRIPTION
In Actual code, `path` is used instead of `content` described in document.

Menu document:
https://svelte-mui.now.sh/menu

Actual code:
https://github.com/vikignt/svelte-mui/blob/master/example/src/pages/menu/Menu.svelte

Icon document: 
https://svelte-mui.now.sh/icon

Thanks for your great work!