### PR TITLE
Add svelte field and remove sapper note 

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,6 @@ Modify file `src/App.svelte` in the following way
 </Button>
 ```
 
-_Note for the [sapper](https://sapper.svelte.dev/) application, you must import components from `svelte-mui/src` like so_
-
-```js
-    import { Button, Checkbox } from 'svelte-mui/src';
-```
-
 ...then start [Rollup](https://rollupjs.org/)
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"url": "https://github.com/vikignt/svelte-mui.git"
 	},
 	"license": "MIT",
+	"svelte": "src/index.js",
 	"module": "index.mjs",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
See the [Svelte Component Template](https://github.com/sveltejs/component-template#consuming-components) for a more detailed description.
Basically tells rollup/webpack that there is source code for svelte files available for it to consume directly instead of using the compiled/dist versions. Removes need to type `svelte-mui/src` on sapper projects adhering to the default templates.