### PR TITLE
Add textfieldStyle prop to the Datefield.svelte component.

### DIFF
--- a/src/Datefield.svelte
+++ b/src/Datefield.svelte
@@ -68,7 +68,7 @@
 	export let disabled = null;
 	export let format = FORMAT_DEFAULT;
 	export let isAllowed = () => true;
-	export let textfieldStyle = undefined
+	export let textfieldStyle = undefined;
 
 	const events = getEventsAction(current_component);
 	const dispatch = createEventDispatcher();

--- a/src/Datefield.svelte
+++ b/src/Datefield.svelte
@@ -24,7 +24,7 @@
 		on:keydown={onkeydown}
 		on:focus={onfocus}
 		on:blur={onblur}
-		style={`padding-right: ${icon ? 0 : 21}px;`}
+		style={`padding-right: ${icon ? 0 : 21}px; ${textfieldStyle}`}
 	/>
 
 	{#if !icon}
@@ -68,6 +68,7 @@
 	export let disabled = null;
 	export let format = FORMAT_DEFAULT;
 	export let isAllowed = () => true;
+	export let textfieldStyle = undefined
 
 	const events = getEventsAction(current_component);
 	const dispatch = createEventDispatcher();


### PR DESCRIPTION
With this PR it is possible to pass individual css style to the child Textfield.svelte component of the Datefeld.svelte component without overriding the current style ``padding-right: ${icon ? 0 : 21}px;`
For e.g. it opens the possibility to alter the style of the textfield when a chosen date is not valid.