### PR TITLE
Dispatch events for onfocus and onblur

### DIFF
--- a/src/Datefield.svelte
+++ b/src/Datefield.svelte
@@ -126,12 +126,14 @@
 		text = tostring(detail, format);
 		value = typeof value === 'string' ? text : clone(detail);
 		visible = false;
-		readonly ? setval(text) : focusInputElm();
+		setval(text);
+		focusInputElm();
 	}
 
 	function onfocus() {
 		inputActive = true;
 		readonly && open();
+		dispatch('focus', e);
 	}
 
 	function onblur(e) {
@@ -142,6 +144,7 @@
 				return;
 			}
 			setval(text);
+			dispatch('blur', e);
 		}, 0);
 	}
 


### PR DESCRIPTION
This PR adds a event dispatch to the onfocus and onblur function.  This is needed to correctly display external validation error passed into the Datefield.svelte component.

This PR also alters the behavior of the onselect function. I changed the code to always setVal(text) when the onselect function is triggered. Without this changen we had some funky behavior with the datepicker value in our form state.



